### PR TITLE
Add syntax highlighting for *.session files in kitty dir

### DIFF
--- a/ftdetect/kitty.vim
+++ b/ftdetect/kitty.vim
@@ -1,6 +1,8 @@
 autocmd! BufNewFile,BufRead kitty.conf setfiletype kitty
 if exists("$XDG_CONFIG_HOME")
   autocmd! BufNewFile,BufRead $XDG_CONFIG_HOME/kitty/*.conf    set ft=kitty syntax=kitty
+  autocmd! BufNewFile,BufRead $XDG_CONFIG_HOME/kitty/*.session set ft=kitty-session syntax=kitty-session
 else
-  autocmd! BufNewFile,BufRead ~/.config/kitty/*.conf   set ft=kitty syntax=kitty
+  autocmd! BufNewFile,BufRead ~/.config/kitty/*.conf    set ft=kitty syntax=kitty
+  autocmd! BufNewFile,BufRead ~/.config/kitty/*.session set ft=kitty-session syntax=kitty-session
 endif

--- a/syntax/kitty-session.vim
+++ b/syntax/kitty-session.vim
@@ -1,0 +1,31 @@
+" Vim syntax file
+" Language: Kitty session
+
+if exists("b:current_syntax")
+  finish
+endif
+
+syn match kittyKW '^\S*' contains=kittySessionCommand,kittyInvalidKeyword
+syn match kittyInvalidKeyword '\S*' contained
+syn match kittyComment /^\s*#.*$/ contains=kittyTodo
+syn region kittyString start=+"+ skip=+\\\\\|\\"+ end=+"+ oneline
+syn region kittyString start=+'+ skip=+\\\\\|\\'+ end=+'+ oneline
+syn keyword kittyTodo contained TODO FIXME XXX contained
+
+syn keyword kittySessionCommand
+	\ new_tab
+	\ new_os_window
+	\ layout
+	\ launch
+	\ focus
+	\ enabled_layouts
+	\ cd
+	\ title
+	\ os_window_size
+	\ os_window_class
+
+hi def link kittySessionCommand Keyword
+hi def link kittyComment Comment
+hi def link kittyTodo	Todo
+hi def link kittyInvalidKeyword Error
+hi def link kittyString String


### PR DESCRIPTION
Basic highlighting for `*.session` files (only detected if below kitty's config dir). No auto-update script, as currently the available commands only occur in a long if-elseif... function and aren't as easily readable programmatically as the commands for the conf file. But the number of available commands is still pretty low, so it should be manageable manually.