### PR TITLE
Add syntax group for colors and numbers

### DIFF
--- a/syntax/kitty.vim
+++ b/syntax/kitty.vim
@@ -2,8 +2,7 @@ syn match kittySt '.*$' contains=kittyNumber,kittyColor
 syn match kittyColor '#\x\{3,8}' contained
 syn match kittyNumber '\s[+-]\?\d\+\.\?\d*\(%\|px\|pt\|em\)\?'ms=s+1 contained contains=kittyUnit
 syn match kittyUnit '\(px\|pt\|em\)' contained
-" Match keywords only at the start of the line. Must come before other rules
-" matching start of line
+
 syn match kittyKW '^\S*' contains=kittyKeyword,kittyInvalidKeyword nextgroup=kittySt
 syn match kittyComment /^\s*#.*$/ contains=kittyTodo
 syn region kittyString start=+"+ skip=+\\\\\|\\"+ end=+"+ oneline

--- a/syntax/kitty.vim
+++ b/syntax/kitty.vim
@@ -1,5 +1,5 @@
 syn match kittySt '.*$' contains=kittyNumber,kittyColor
-syn match kittyColor '#[^:].*' contained
+syn match kittyColor '#[0-9A-Fa-f]\{6,8}' contained
 syn match kittyNumber '[0-9]\+\.\?[0-9]*' contained
 " Match keywords only at the start of the line. Must come before other rules
 " matching start of line

--- a/syntax/kitty.vim
+++ b/syntax/kitty.vim
@@ -1,6 +1,6 @@
 syn match kittySt '.*$' contains=kittyNumber,kittyColor
 syn match kittyColor '#\x\{3,8}' contained
-syn match kittyNumber '[+-]\?\d\+\.\?\d*\(%\|px\|pt\|em\)\?' contained contains=kittyUnit
+syn match kittyNumber '\s[+-]\?\d\+\.\?\d*\(%\|px\|pt\|em\)\?'ms=s+1 contained contains=kittyUnit
 syn match kittyUnit '\(px\|pt\|em\)' contained
 " Match keywords only at the start of the line. Must come before other rules
 " matching start of line

--- a/syntax/kitty.vim
+++ b/syntax/kitty.vim
@@ -19,7 +19,7 @@ syn match kittyInvalidKeyword '\S*' contained
 
 
 syn region kittyKeybind start=' ' end=' ' contains=kittyMod,kittyKey,kittyKeyComb contained nextgroup=kittyActionKW
-syn match kittyActionKW '\s*\S*\s*' contained contains=kittyAction,kittyInvalidAction
+syn match kittyActionKW '\s*\S*' contained contains=kittyAction,kittyInvalidAction
 syn match kittyInvalidAction '\S*' contained
 
 

--- a/syntax/kitty.vim
+++ b/syntax/kitty.vim
@@ -1,6 +1,7 @@
 syn match kittySt '.*$' contains=kittyNumber,kittyColor
-syn match kittyColor '#[0-9A-Fa-f]\{6,8}' contained
-syn match kittyNumber '[0-9]\+\.\?[0-9]*' contained
+syn match kittyColor '#\x\{3,8}' contained
+syn match kittyNumber '[+-]\?\d\+\.\?\d*\(%\|px\|pt\|em\)\?' contained contains=kittyUnit
+syn match kittyUnit '\(px\|pt\|em\)' contained
 " Match keywords only at the start of the line. Must come before other rules
 " matching start of line
 syn match kittyKW '^\S*' contains=kittyKeyword,kittyInvalidKeyword nextgroup=kittySt
@@ -37,6 +38,7 @@ hi def link kittyInvalidKeyword Error
 hi def link kittyInclude Include
 hi def link kittyColor Number
 hi def link kittyNumber Number
+hi def link kittyUnit Type
 
 let b:current_syntax = "kitty"
 

--- a/syntax/kitty.vim
+++ b/syntax/kitty.vim
@@ -1,6 +1,9 @@
+syn match kittySt '.*$' contains=kittyNumber,kittyColor
+syn match kittyColor '#[^:].*' contained
+syn match kittyNumber '[0-9]\+\.\?[0-9]*' contained
 " Match keywords only at the start of the line. Must come before other rules
 " matching start of line
-syn match kittyKW '^\S*' contains=kittyKeyword,kittyInvalidKeyword
+syn match kittyKW '^\S*' contains=kittyKeyword,kittyInvalidKeyword nextgroup=kittySt
 syn match kittyComment /^\s*#.*$/ contains=kittyTodo
 syn region kittyString start=+"+ skip=+\\\\\|\\"+ end=+"+ oneline
 syn region kittyString start=+'+ skip=+\\\\\|\\'+ end=+'+ oneline
@@ -32,6 +35,8 @@ hi def link kittyMod Constant
 hi def link kittyInvalidAction Error
 hi def link kittyInvalidKeyword Error
 hi def link kittyInclude Include
+hi def link kittyColor Number
+hi def link kittyNumber Number
 
 let b:current_syntax = "kitty"
 


### PR DESCRIPTION
Highlight Numbers and colors as Numbers
Giving colors a group now allows for using https://github.com/ap/vim-css-color types plugins

I am definitely not an expert in pattern matching so I've felt my way along and stopped when it worked
Any advice on how to improve those patterns is very welcome.

Signed-off-by: Fymyte <pierguill@gmail.com>