### PR TITLE
Fix ftdetect pattern.

### DIFF
--- a/ftdetect/kitty.vim
+++ b/ftdetect/kitty.vim
@@ -1,1 +1,1 @@
-autocmd! BufNewFile,BufRead kitty.conf setfiletype kitty,*/kitty/*.conf,*/*.session
+autocmd! BufNewFile,BufRead kitty.conf,*/kitty/*.conf,*/*.session setfiletype kitty


### PR DESCRIPTION
Hi,

Thanks for the plugin!

The most recent commit (https://github.com/fladson/vim-kitty/pull/15) broke the filetype detection for me when using this plugin. I think the problem is just a syntax error with part of the autocmd pattern appended to the filetype. I've moved the `,*/kitty/*.conf,*/*.session` part back into the pattern and it works as expected.