### PR TITLE
Recognize `#:` comment syntax in `kitty.conf`

### DIFF
--- a/ftdetect/kitty.vim
+++ b/ftdetect/kitty.vim
@@ -1,2 +1,3 @@
 autocmd! BufNewFile,BufRead kitty.conf,*/kitty/*.conf setfiletype kitty
 autocmd! BufNewFile,BufRead */kitty/*.session setfiletype kitty-session
+set comments+=b:#,b:#\:


### PR DESCRIPTION
`kitty.conf` syntactically uses `#` for comments, but as a [style choice](https://github.com/kovidgoyal/kitty/pull/645#issuecomment-397826696) uses `#:` for documentation-only comments.

Because by default (neo)vim only recognizes `#`, operations like wrapping or combining lines for `#:` break. This PR fixes these breakages by adding `#:` as a comment symbol. It also explicitly adds `#` as a comment symbol, in case it's not in the user's defaults already.

For more info on this (neo)vim behavior see `:help comments`.

Example of breakage when wrapping lines with `gqj..` before this change:

https://user-images.githubusercontent.com/438911/172469151-9fb9dba4-397d-4b09-98d3-1d4ef71d90ce.mov

Example of correct behavior when wrapping lines with `gqj..` after this change:

https://user-images.githubusercontent.com/438911/172469197-07d62c96-03cf-43d3-a2d0-4bee164bda1c.mov