### PR TITLE
fix: do not set comments in ftdetect

### DIFF
--- a/ftdetect/kitty.vim
+++ b/ftdetect/kitty.vim
@@ -1,3 +1,2 @@
 autocmd! BufNewFile,BufRead kitty.conf,*/kitty/*.conf setfiletype kitty
 autocmd! BufNewFile,BufRead */kitty/*.session setfiletype kitty-session
-set comments+=b:#,b:#\:


### PR DESCRIPTION
ftdetect is run on every new buffer to probe the filetype.
It should not change any global options if it is not the
expected filetype.
