### PR TITLE
Add support for vim's built-in spell checker

### DIFF
--- a/syntax/kitty.vim
+++ b/syntax/kitty.vim
@@ -1,6 +1,7 @@
 syn region kittyKeybind start=' ' end=' ' contains=kittyMod,kittyKey,kittyKeyComb contained nextgroup=kittyActionKW
 syn region kittyString start=+"+ skip=+\\\\\|\\"+ end=+"+ oneline
 syn region kittyString start=+'+ skip=+\\\\\|\\'+ end=+'+ oneline
+syn spell notoplevel
 
 " the order here matters
 syn match kittySt '.*$' contains=kittyNumber,kittyColor
@@ -8,7 +9,7 @@ syn match kittyColor '#\x\{3,8}' contained
 syn match kittyNumber '\s[+-]\?\d\+\.\?\d*\(%\|px\|pt\|em\)\?'ms=s+1 contained contains=kittyUnit
 syn match kittyUnit '\(px\|pt\|em\)' contained
 syn match kittyKW '^\s*\S*' contains=kittyKeyword,kittyInvalidKeyword nextgroup=kittySt
-syn match kittyComment /^\s*#.*$/ contains=kittyTodo
+syn match kittyComment /^\s*#.*$/ contains=kittyTodo,@Spell
 syn match kittyInclude '^\s*\(env\|glob\)\?include' display
 syn match kittyMap '^\s*\(mouse_\)\?map' nextgroup=kittyKeybind
 syn match kittyContinue '^\(\s\+\)\?\\'


### PR DESCRIPTION
This adds support for telling the spellchecker which parts of the syntax are worth checking, ie. just the comments.

Reference docs: https://neovim.io/doc/user/spell.html#spell-syntax

Before:

![image](https://github.com/user-attachments/assets/f6dd1648-511c-4764-9154-cb97df5bdfa1)

After:

![image](https://github.com/user-attachments/assets/a301948c-7775-4647-8ce9-810868831d22)
